### PR TITLE
Restore and publish pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ __filesSlothRestore.py__ - Find and restore deleted file objects
 __filesDeleteLoad.py__ - Deletes file objects by id  
 __urlMappingLoad.py__ - Bulk edit and create URL mapping objects   
 __urlMappingSlothRestore.py__ - Find and restore deleted mapping objects   
-__postsSlothRestore.py__ - Find and restore deleted post objects   
+__postsSlothRestore.py__ - Find and restore deleted post objects  
+__pagesSlothRestorePublish.py__ - Find, restore and publish deleted page objects 
 __cmsFinder.py__ - Figures out which CMS a page uses and grades it in PSI (desktop and mobile)   
 __cdn1Replacer.py__ - Finds cdn1 image src uri in post bodies, and replaces them with newly uploaded cdn2 files  
 
@@ -111,6 +112,22 @@ This Python python takes three agruments: `accessToken`, `slothStart` & `content
 $ python3 postsSlothRestore.py 1234-5678-9123-4567 1529816400000 2509275571  
 ```
 Runs `postsSlothRestore.py` finding posts deleted after 1529816400000 (June 24th, 2018 0:00:00) for portal with access token `1234-5678-9123-4567` in blog `2509275571`   
+
+## pagesSlothRestorePublish.py
+A Python python to find deleted pages, restore, and publish them  
+_REQUIRES_  
+[requests](http://docs.python-requests.org/en/master/)  
+
+_USAGE_  
+This Python python takes three agruments: `accessToken`, `slothStart`  
+
+`accessToken` - An access_token for the portal you want to urlMappingSlothRestore  
+`slothStart` - A millisecond unix timestamp used in the `deleted_at__gt` request parameter to dictate the start time of file deletion timestamps to GET  
+
+```
+$ python3 pagesSlothRestore.py 1234-5678-9123-4567 1529816400000 2509275571  
+```
+Runs `pagesSlothRestore.py` finding pages deleted after 1529816400000 (June 24th, 2018 0:00:00) for portal with access token `1234-5678-9123-4567` and publishes them    
 
 ## cmsFinder.py
 _REQUIRES_  

--- a/README.md
+++ b/README.md
@@ -119,15 +119,15 @@ _REQUIRES_
 [requests](http://docs.python-requests.org/en/master/)  
 
 _USAGE_  
-This Python python takes three agruments: `accessToken`, `slothStart`  
+This Python python takes two arguments: `accessToken`, `slothStart`  
 
 `accessToken` - An access_token for the portal you want to urlMappingSlothRestore  
 `slothStart` - A millisecond unix timestamp used in the `deleted_at__gt` request parameter to dictate the start time of file deletion timestamps to GET  
 
 ```
-$ python3 pagesSlothRestore.py 1234-5678-9123-4567 1529816400000 2509275571  
+$ python3 pagesSlothRestorePublish.py 1234-5678-9123-4567 1529816400000    
 ```
-Runs `pagesSlothRestore.py` finding pages deleted after 1529816400000 (June 24th, 2018 0:00:00) for portal with access token `1234-5678-9123-4567` and publishes them    
+Runs `pagesSlothRestorePublish.py` finding pages deleted after 1529816400000 (June 24th, 2018 0:00:00) for portal with access token `1234-5678-9123-4567` and publishes them    
 
 ## cmsFinder.py
 _REQUIRES_  

--- a/pagesSlothRestorePublish.py
+++ b/pagesSlothRestorePublish.py
@@ -1,0 +1,31 @@
+from time import sleep
+import requests
+import json
+import sys
+
+accessToken = sys.argv[1]
+slothStart = sys.argv[2]
+pagesApiBase = "https://api.hubapi.com/content/api/v4/pages"
+pagesSlothApiQuery = (f"access_token={accessToken}&includeDeleted=true&deletedAt__gt={slothStart}&limit=1")
+
+slothedPages = requests.get(pagesApiBase, params=pagesSlothApiQuery)
+slothedPageObjects = slothedPages.json()["objects"]
+deletedPagesIdsCount = len(slothedPageObjects)
+print (f"Hold your butts! Restoring {deletedPagesIdsCount} pages :butt-holdings:")
+
+for slothedPageObject in slothedPageObjects:
+    slothedPageId = slothedPageObject["id"]
+    pageApiRestore = (f"{pagesApiBase}/{slothedPageId}/restore-deleted?access_token={accessToken}")
+    restorePage = requests.put(pageApiRestore)
+    if restorePage.status_code == 200:
+        print (f"Restored page id {slothedPageId}, trying to publish it now")
+        pageRestoreRequestUri = (f"https://api.hubspot.com/cospages/v1/landing-pages/{slothedPageId}/publish-action?access_token={accessToken}")
+        publishPagePayload = {'action': 'schedule-publish'}
+        restoredPage = requests.post(pageRestoreRequestUri, json=publishPagePayload)
+        if restoredPage.status_code == 204:
+            print (f"Published page id {slothedPageId}")
+        else:
+            print (f"Failed to publish page id {slothedPageId}")
+    else:
+        print (f"Hmmm, something went wrong resoring page id {slothedPageId}")
+    sleep(.33)


### PR DESCRIPTION
A Python script to find deleted pages, restore, and publish them  
_REQUIRES_  
[requests](http://docs.python-requests.org/en/master/)  

_USAGE_  
This Python python takes two arguments: `accessToken`, `slothStart`  

`accessToken` - An access_token for the portal you want to urlMappingSlothRestore  
`slothStart` - A millisecond unix timestamp used in the `deleted_at__gt` request parameter to dictate the start time of file deletion timestamps to GET  

```
$ python3 pagesSlothRestorePublish.py 1234-5678-9123-4567 1529816400000    
```
Runs `pagesSlothRestorePublish.py` finding pages deleted after 1529816400000 (June 24th, 2018 0:00:00) for portal with access token `1234-5678-9123-4567` and publishes them 