### PR TITLE
Add restore and pub for posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ $ python3 postsSlothRestore.py 1234-5678-9123-4567 1529816400000 2509275571
 ```
 Runs `postsSlothRestore.py` finding posts deleted after 1529816400000 (June 24th, 2018 0:00:00) for portal with access token `1234-5678-9123-4567` in blog `2509275571`   
 
+## postsSlothRestorePublish.py
+A Python python to find deleted posts and restore them (if they were published at the time of deletion AND they were deleted by the target user)  
+_REQUIRES_  
+[requests](http://docs.python-requests.org/en/master/)  
+
+_USAGE_  
+This Python python takes four agruments: `accessToken`, `slothStart`, `contentGroupId`, & `targetDeletedBy`    
+`accessToken` - An access_token for the portal you want to affect
+`slothStart` - A millisecond unix timestamp used in the `deleted_at__gt` request parameter to dictate the start time of file deletion timestamps to GET  
+`contentGroupId` - The blog id to find deleted posts in
+`targetDeletedBy` - The email address of the user who deleted the post
+
+```
+$ python3 postsSlothRestorePublish.py 1234-5678-9123-4567 1529816400000 2509275571 john_doe@gmail.com 
+```
+Runs `postsSlothRestorePublish.py` finding posts deleted after 1529816400000 (June 24th, 2018 0:00:00) by john_doe@gmail.com for portal with access token `1234-5678-9123-4567` in blog `2509275571` and republishes them if they were published when john_doe deleted them. 
+
 ## pagesSlothRestorePublish.py
 A Python python to find deleted pages, restore, and publish them  
 _REQUIRES_  

--- a/postsSlothRestorePublish.py
+++ b/postsSlothRestorePublish.py
@@ -1,0 +1,43 @@
+from time import sleep
+import requests
+import json
+import sys
+
+accessToken = sys.argv[1]
+slothStart = sys.argv[2]
+contentGroupId = sys.argv[3]
+targetDeletedBy = sys.argv[4]
+postsApiBase = "https://api.hubapi.com/blogs/v3/blog-posts"
+postsSlothApiQuery = (f"access_token={accessToken}&includeDeleted=true&deletedAt__gt={slothStart}&limit=1000&content_group_id={contentGroupId}")
+
+slothedPosts = requests.get(postsApiBase, params=postsSlothApiQuery)
+slothedPostObjects = slothedPosts.json()["objects"]
+deletedPostsIdsCount = len(slothedPostObjects)
+print (f"Hold your butts! Restoring {deletedPostsIdsCount} posts :butt-holdings:")
+
+for slothedPostObject in slothedPostObjects:
+    slothedPostId = slothedPostObject["id"]
+    slothedDeletedBy = slothedPostObject["deletedBy"]
+    slothedstate_when_deleted = slothedPostObject["meta"]["state_when_deleted"]
+    postApiRestore = (f"{postsApiBase}/{slothedPostId}/restore-deleted?access_token={accessToken}")
+    if slothedDeletedBy == targetDeletedBy and slothedstate_when_deleted == "PUBLISHED":
+        restorePost = requests.put(postApiRestore)
+        if restorePost.status_code == 200:
+            postRestoreRequestUri = (f"{postsApiBase}/{slothedPostId}/publish-action?access_token={accessToken}")
+            publishPostPayload = {'action': 'schedule-publish'}
+            publishedPost = requests.post(postRestoreRequestUri, json=publishPostPayload)
+            if publishedPost.status_code == 204:
+                print (f"Restored and published post id {slothedPostId}")
+            else:
+                print (f"Failed to publish post id {slothedPostId}, but it was restored. publish failed with {publishedPost.status_code}")
+        else:
+            print (f"Hmmm, something went wrong resoring post id {slothedPostId}")
+    elif slothedstate_when_deleted != "PUBLISHED":
+        restorePost = requests.put(postApiRestore)
+        if restorePost.status_code == 200:
+            print (f"Restored post id {slothedPostId}, but did not publish it as it was not PUBLISHED when deleted (it was {slothedstate_when_deleted})")
+        else: 
+            print (f"Hmmm, something went wrong restoring post id {slothedPostId}. {restorePost.url}, {restorePost.status_code}")
+    else: 
+        print (f"Found deleted post {slothedPostId}, but it was not deleted by {targetDeletedBy} (it was deleted by {slothedDeletedBy})")
+    sleep(.33)


### PR DESCRIPTION
Adds a script to find deleted blog posts under a particular blog and republishes them if they were (1) published at the time of deletion (2) deleted by a target user (email)